### PR TITLE
Fixed navbar from overflowing the page on mobile

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -22,9 +22,9 @@
           "dev": true
         },
         "ts-node": {
-          "version": "8.6.2",
-          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.6.2.tgz",
-          "integrity": "sha512-4mZEbofxGqLL2RImpe3zMJukvEvcO1XP8bj8ozBPySdCUXEcU5cIRwR0aM3R+VoZq7iXc8N86NC0FspGRqP4gg==",
+          "version": "8.8.1",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.8.1.tgz",
+          "integrity": "sha512-10DE9ONho06QORKAaCBpPiFCdW+tZJuY/84tyypGtl6r+/C7Asq0dhqbRZURuUlLQtZxxDvT8eoj8cGW0ha6Bg==",
           "dev": true,
           "requires": {
             "arg": "^4.1.0",

--- a/website/src/app/itemlist-page/itemlist-page.component.html
+++ b/website/src/app/itemlist-page/itemlist-page.component.html
@@ -1,7 +1,7 @@
 <app-navbar></app-navbar>
 
 <div class="bg-white-alpha-80 dark:bg-black-alpha-20">
-  <nav class="flex overflow-auto text-nowrap flex-row text-center text-gray-600 dark:text-gray-500">
+  <nav class="flex flex-wrap flex-row text-center text-gray-600 dark:text-gray-500">
     <a *ngFor="let type of byType | keyvalue" routerLink="/items" [queryParams]="{type: type.key}" routerLinkActive="text-white bg-primary" class="px-5 py-3 flex-grow hover:text-black dark-hover:text-white">{{type.key}}</a>
   </nav>
 </div>

--- a/website/src/app/itemlist-page/itemlist-page.component.html
+++ b/website/src/app/itemlist-page/itemlist-page.component.html
@@ -1,7 +1,7 @@
 <app-navbar></app-navbar>
 
 <div class="bg-white-alpha-80 dark:bg-black-alpha-20">
-  <nav class="flex flex-wrap flex-row text-center text-gray-600 dark:text-gray-500">
+  <nav class="flex overflow-auto text-nowrap flex-row text-center text-gray-600 dark:text-gray-500">
     <a *ngFor="let type of byType | keyvalue" routerLink="/items" [queryParams]="{type: type.key}" routerLinkActive="text-white bg-primary" class="px-5 py-3 flex-grow hover:text-black dark-hover:text-white">{{type.key}}</a>
   </nav>
 </div>

--- a/website/src/app/navbar/navbar.component.html
+++ b/website/src/app/navbar/navbar.component.html
@@ -1,6 +1,6 @@
 <nav class="bg-white-alpha-90 dark:bg-black-alpha-40">
 
-  <div class="container mx-auto px-5 py-3 flex lg:flex-row items-baseline text-gray-600 dark:text-gray-500">
+  <div class="container overflow-auto mx-auto px-5 py-3 flex lg:flex-row items-baseline text-gray-600 dark:text-gray-500">
     <a class="text-xl text-primary caps-small text-shadow-sm mr-5" routerLink="/">SCunpacked</a>
     <a class="mr-5 hover:text-black dark-hover:text-white" routerLink="/ships" routerLinkActive="text-black dark:text-white">Ships</a>
     <a class="mr-5 hover:text-black dark-hover:text-white" routerLink="/items" routerLinkActive="text-black dark:text-white">Items</a>

--- a/website/src/styles.scss
+++ b/website/src/styles.scss
@@ -29,9 +29,7 @@ a:hover {
   font-variant: small-caps;
 }
 
-
 /***** Colours *****/
-
 .container-inner {
   a:not(.btn) {
     color: deeppink;


### PR DESCRIPTION
Fixed navbar from overflowing the page on mobile. Instead of going out of the page, now it is scrollable when the width is too small.