### PR TITLE
Make hardpoint table responsive

### DIFF
--- a/website/src/app/itemgroup/itemgroup.component.html
+++ b/website/src/app/itemgroup/itemgroup.component.html
@@ -4,13 +4,13 @@
 
   <ng-container *ngFor="let class of groupItems | keyvalue">
 
-    <div (click)="toggleItems(class.key)" class="flex border-gray-600 border-b last:border-b-0 cursor-pointer items-center pl-4">
+    <div (click)="toggleItems(class.key)" class="flex flex-col md:flex-row border-gray-600 border-b last:border-b-0 cursor-pointer items-center">
 
       <!-- Item group name -->
-      <div class="flex-grow font-bold">{{class.key}}</div>
+      <div class="flex-grow md:pl-4 font-bold">{{class.key}}</div>
 
       <!-- Size boxes -->
-      <div class="flex-shrink-0 flex">
+      <div class="flex-shrink-0 flex overflow-auto w-full md:w-auto">
         <div *ngFor="let size of class.value.bySize; let s = index" class="size-box border-gray-600 border-l">
           <div *ngIf="size.length" class="size-box-inner bg-primary">
             <span class="text-xs text-white text-opacity-80">S{{s}}</span><br>

--- a/website/src/app/itemport/itemport.component.html
+++ b/website/src/app/itemport/itemport.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="itemPort.Category !== 'Weapon attachments'" class="flex items-center">
+<div *ngIf="itemPort.Category !== 'Weapon attachments'" class="flex items-center overflow-auto sm:whitespace-nowrap md:whitespace-normal">
 
   <!-- Size box -->
   <div class="size-box-inner flex-shrink-0 flex items-center justify-center w-8 h-8 my-2 mr-4 text-xs" [class.bg-primary]="itemPort.InstalledItem" [class.bg-gray-900]="!itemPort.InstalledItem">

--- a/website/src/app/itemport/itemport.component.html
+++ b/website/src/app/itemport/itemport.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="itemPort.Category !== 'Weapon attachments'" class="flex items-center overflow-auto sm:whitespace-nowrap md:whitespace-normal">
+<div *ngIf="itemPort.Category !== 'Weapon attachments'" class="flex items-center overflow-auto whitespace-nowrap md:whitespace-normal">
 
   <!-- Size box -->
   <div class="size-box-inner flex-shrink-0 flex items-center justify-center w-8 h-8 my-2 mr-4 text-xs" [class.bg-primary]="itemPort.InstalledItem" [class.bg-gray-900]="!itemPort.InstalledItem">


### PR DESCRIPTION
The hardpoint table on ship pages was overflowing in smaller screen size.
I moved the table header to column and add scrolling to help mitigate the issue, it should be more usable on mobile now.

I attached a few screenshots comparing the original and the patch on the iPhone X viewport.
Original:
![scunpacked com_ships_aegs_avenger_stalker(iPhone X)](https://user-images.githubusercontent.com/9260542/103141351-3367b880-46c1-11eb-9376-c725c66f2aca.png)

Responsive:
![localhost_4200_ships_aegs_avenger_stalker(iPhone X)](https://user-images.githubusercontent.com/9260542/103141356-3c588a00-46c1-11eb-98c8-635c88d23e4f.png)