### PR TITLE
Fix overlap credits on home page

### DIFF
--- a/website/src/app/home-page/home-page.component.html
+++ b/website/src/app/home-page/home-page.component.html
@@ -26,7 +26,7 @@
 
 </div>
 
-<div class="container mx-auto max-w-7xl p-10 mt-10 bg-black bg-opacity-80">
+<div class="container mx-auto max-w-7xl p-10 mt-10 sm:mb-56 bg-black bg-opacity-80">
 
   <h2 class="text-2xl">Latest updates</h2>
 

--- a/website/src/app/home-page/home-page.component.scss
+++ b/website/src/app/home-page/home-page.component.scss
@@ -39,7 +39,7 @@
   }
 }
 
-@media (max-width: 767px) {
+@media (max-width: 640px) {
   .credits {
     flex-direction: column;
     position: relative;


### PR DESCRIPTION
The fixed credit on the home page overlap with the content.
I added a bottom margin when the credit is fixed to prevent the issue.