### PR TITLE
Navbar style tweaks

### DIFF
--- a/website/src/app/navbar/navbar.component.html
+++ b/website/src/app/navbar/navbar.component.html
@@ -1,6 +1,6 @@
 <nav class="bg-gray-800 border-b border-gray-700 border-opacity-50">
 
-  <div class="container whitespace-nowrap overflow-auto mx-auto flex lg:flex-row items-baseline text-sm text-gray-400 font-medium">
+  <div class="xl:container px-1 whitespace-nowrap overflow-auto xl:mx-auto flex lg:flex-row items-baseline text-sm text-gray-400 font-medium">
     <a class="mr-1 px-2 py-3 uppercase leading-6 tracking-wide" routerLink="/"><span class="font-bold text-gray-200">SC</span><span>unpacked</span></a>
     <a class="px-2 py-3 hover:text-white" routerLink="/ships" routerLinkActive="text-white">Ships</a>
     <a class="px-2 py-3 hover:text-white" routerLink="/items" routerLinkActive="text-white">Ship equipment</a>

--- a/website/src/app/navbar/navbar.component.html
+++ b/website/src/app/navbar/navbar.component.html
@@ -1,6 +1,6 @@
 <nav class="bg-gray-800 border-b border-gray-700 border-opacity-50">
 
-  <div class="container overflow-auto mx-auto flex lg:flex-row items-baseline text-sm text-gray-400 font-medium">
+  <div class="container whitespace-nowrap overflow-auto mx-auto flex lg:flex-row items-baseline text-sm text-gray-400 font-medium">
     <a class="mr-1 px-2 py-3 uppercase leading-6 tracking-wide" routerLink="/"><span class="font-bold text-gray-200">SC</span><span>unpacked</span></a>
     <a class="px-2 py-3 hover:text-white" routerLink="/ships" routerLinkActive="text-white">Ships</a>
     <a class="px-2 py-3 hover:text-white" routerLink="/items" routerLinkActive="text-white">Ship equipment</a>

--- a/website/src/app/navbar/navbar.component.html
+++ b/website/src/app/navbar/navbar.component.html
@@ -1,7 +1,7 @@
-<nav class="bg-black bg-opacity-60">
+<nav class="bg-gray-800 border-b border-gray-700 border-opacity-50">
 
-  <div class="container overflow-auto mx-auto px-5 py-3 flex lg:flex-row items-baseline text-gray-400 space-x-5">
-    <a class="text-xl text-primary smallcaps text-shadow-sm" routerLink="/">SCunpacked</a>
+  <div class="container overflow-auto mx-auto px-5 py-3 flex lg:flex-row items-baseline text-sm text-gray-400 font-medium space-x-5">
+    <a class="uppercase leading-6 tracking-wide" routerLink="/"><span class="font-bold text-gray-200">SC</span><span>unpacked</span></a>
     <a class="hover:text-white" routerLink="/ships" routerLinkActive="text-white">Ships</a>
     <a class="hover:text-white" routerLink="/items" routerLinkActive="text-white">Ship equipment</a>
     <a class="hover:text-white" routerLink="/fps-weapons" routerLinkActive="text-white">FPS gear</a>

--- a/website/src/app/navbar/navbar.component.html
+++ b/website/src/app/navbar/navbar.component.html
@@ -1,15 +1,15 @@
 <nav class="bg-gray-800 border-b border-gray-700 border-opacity-50">
 
-  <div class="container overflow-auto mx-auto px-5 py-3 flex lg:flex-row items-baseline text-sm text-gray-400 font-medium space-x-5">
-    <a class="uppercase leading-6 tracking-wide" routerLink="/"><span class="font-bold text-gray-200">SC</span><span>unpacked</span></a>
-    <a class="hover:text-white" routerLink="/ships" routerLinkActive="text-white">Ships</a>
-    <a class="hover:text-white" routerLink="/items" routerLinkActive="text-white">Ship equipment</a>
-    <a class="hover:text-white" routerLink="/fps-weapons" routerLinkActive="text-white">FPS gear</a>
-    <a class="hover:text-white" routerLink="/shops" routerLinkActive="text-white">Shops</a>
-    <a class="hover:text-white" routerLink="/commodities" routerLinkActive="text-white">Commodities</a>
+  <div class="container overflow-auto mx-auto flex lg:flex-row items-baseline text-sm text-gray-400 font-medium">
+    <a class="mr-1 px-2 py-3 uppercase leading-6 tracking-wide" routerLink="/"><span class="font-bold text-gray-200">SC</span><span>unpacked</span></a>
+    <a class="px-2 py-3 hover:text-white" routerLink="/ships" routerLinkActive="text-white">Ships</a>
+    <a class="px-2 py-3 hover:text-white" routerLink="/items" routerLinkActive="text-white">Ship equipment</a>
+    <a class="px-2 py-3 hover:text-white" routerLink="/fps-weapons" routerLinkActive="text-white">FPS gear</a>
+    <a class="px-2 py-3 hover:text-white" routerLink="/shops" routerLinkActive="text-white">Shops</a>
+    <a class="px-2 py-3 hover:text-white" routerLink="/commodities" routerLinkActive="text-white">Commodities</a>
     <span class="flex-grow"></span>
-    <span class=""><a href="https://github.com/richardthombs/scunpacked"><i class="fab fa-lg fa-github hover:text-white"></i></a></span>
-    <span class="smallcaps">v3.12.0a LIVE</span>
+    <span class=""><a class="px-2 py-3" href="https://github.com/richardthombs/scunpacked"><i class="fab fa-lg fa-github hover:text-white"></i></a></span>
+    <span class="px-2 smallcaps">v3.12.0a LIVE</span>
   </div>
 
 </nav>


### PR DESCRIPTION
- Width no longer shrink in smaller breakpoints
- Increase clickable area of links
- Remove text wrapping for links
- Change styling for the site logo text
- Use solid gray color for navbar background

In the long run the navigation links after the logo should auto-collapse based on the viewport width, but I am not sure what is the best practice with Angular.

![localhost_4200_(iPad Pro)](https://user-images.githubusercontent.com/9260542/103142668-0b825000-46d5-11eb-9f88-09d12c274710.png)