### PR TITLE
Remove scrollbar styles for small breakpoint

### DIFF
--- a/website/src/styles.scss
+++ b/website/src/styles.scss
@@ -39,28 +39,3 @@ a:hover {
     color: deeppink;
   }
 }
-
-// Scrollbar
-html {
-  --scrollbarBG: transparent;
-  --thumbBG: rgba(255, 20, 147, 0.7);
-}
-
-*::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
-}
-
-* {
-  scrollbar-width: thin;
-  scrollbar-color: var(--thumbBG) var(--scrollbarBG);
-}
-
-*::-webkit-scrollbar-track {
-  background: var(--scrollbarBG);
-}
-
-*::-webkit-scrollbar-thumb {
-  background-color: var(--thumbBG);
-  border: 3px solid var(--scrollbarBG);
-}

--- a/website/src/styles.scss
+++ b/website/src/styles.scss
@@ -39,3 +39,30 @@ a:hover {
     color: deeppink;
   }
 }
+
+/***** Scrollbar *****/
+@media (min-width: 768px) {
+	html {
+	  --scrollbarBG: transparent;
+	  --thumbBG: rgba(255, 20, 147, 0.7);
+	}
+
+	*::-webkit-scrollbar {
+	  width: 6px;
+	  height: 6px;
+	}
+
+	* {
+	  scrollbar-width: thin;
+	  scrollbar-color: var(--thumbBG) var(--scrollbarBG);
+	}
+
+	*::-webkit-scrollbar-track {
+	  background: var(--scrollbarBG);
+	}
+
+	*::-webkit-scrollbar-thumb {
+	  background-color: var(--thumbBG);
+	  border: 3px solid var(--scrollbarBG);
+	}
+}


### PR DESCRIPTION
Custom scrollbar styles make scrollbar always visible and prevent the use of the default hover scrollbar style on mobile devices.
Removing them should provide a better mobile browsing experience.