### PR TITLE
Fix overflow on comparison pages

### DIFF
--- a/website/src/app/compare-items-page/compare-items-page.component.html
+++ b/website/src/app/compare-items-page/compare-items-page.component.html
@@ -1,6 +1,6 @@
 <app-navbar></app-navbar>
 
-<div class="w-fit mx-auto p-10 mt-10 bg-black bg-opacity-80">
+<div class="overflow-auto mx-auto p-10 mt-10 bg-black bg-opacity-80">
 
   <table>
     <ng-container *ngFor="let g of fields; index as gIndex">

--- a/website/src/app/compare-ships-page/compare-ships-page.component.html
+++ b/website/src/app/compare-ships-page/compare-ships-page.component.html
@@ -1,6 +1,6 @@
 <app-navbar></app-navbar>
 
-<div class="w-fit mx-auto p-10 mt-10 bg-black bg-opacity-80">
+<div class="overflow-auto mx-auto p-10 mt-10 bg-black bg-opacity-80">
 
   <table>
     <ng-container *ngFor="let g of fields; index as gIndex">


### PR DESCRIPTION
The content of the comparison table no longer overflow the page width, instead it is scrollable now.